### PR TITLE
Autolink URLs in job descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps
 
-setup: deps build app-key
+setup: deps build app-key db-migrate
 
 dev:
 	docker-compose up client caddy php-fpm db

--- a/app/Job.php
+++ b/app/Job.php
@@ -25,7 +25,7 @@ class Job extends Model
 
     public function getFormattedDescriptionAttribute()
     {
-        return nl2br(e($this->description));
+        return autolinkUrls(nl2br(e($this->description)));
     }
 
     public function scopePublished($query)
@@ -73,4 +73,10 @@ class Job extends Model
     {
         return ! $this->isRecent();
     }
+}
+
+function autolinkUrls($text) {
+    $urlRegex = "/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/i";
+    $replace = "<a href=\"$0\">$0</a>";
+    return preg_replace($urlRegex, $replace, $text);
 }


### PR DESCRIPTION
This PR adds autolinking to URLs that are found in job descriptions.

To test it out, create a job with no URL, and include a URL in the description field, then view that job and check that the URL is clickable.
